### PR TITLE
Handle cases where the single search term isn't a term in our database

### DIFF
--- a/app/controllers/interaction_claims_controller.rb
+++ b/app/controllers/interaction_claims_controller.rb
@@ -30,7 +30,7 @@ class InteractionClaimsController < ApplicationController
     @view_context = view_context
     unpack_locals(params)
     perform_interaction_search
-    if @search_results.search_results.length == 1
+    if @search_results.search_results.length == 1 && @search_results.search_results[0].identifiers.length == 1
       redirect_to "/#{params['search_mode']}/#{ERB::Util.url_encode(@search_results.search_results[0].identifiers[0]['name'])}#_interactions"
     else
       prepare_export


### PR DESCRIPTION
This is a bug that was introduced by https://github.com/dgidb/dgidb/pull/401. When searching for a drug/gene that is not in DGIdb it would attempt to redirect, which would fail. This update will not trigger a redirect in this cases. 